### PR TITLE
Added Audit trail for Decision Tracking

### DIFF
--- a/bkflow_dmn/audit.py
+++ b/bkflow_dmn/audit.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+"""
+Audit module for capturing decision execution traces.
+Uses ContextVar to avoid changing function signatures.
+"""
+from contextvars import ContextVar
+from typing import Optional, List, Dict, Any
+from dataclasses import dataclass, field
+
+@dataclass
+class DecisionTrace:
+    """Represents a single decision table execution trace."""
+    table_title: str
+    facts: Dict[str, Any]
+    matched_rules: List[int]  # Indices of rules that matched
+    rule_results: List[bool]  # Full match vector
+    outputs: List[Any]
+    final_result: List[Dict[str, Any]]
+    # Enhanced details
+    input_expressions: List[List[str]] = field(default_factory=list)  # Raw input expressions per rule
+    output_expressions: List[List[str]] = field(default_factory=list)  # Raw output expressions per rule
+    input_col_ids: List[str] = field(default_factory=list)
+    output_col_ids: List[str] = field(default_factory=list)
+    evaluated_outputs: List[List[str]] = field(default_factory=list)  # Expressions with values substituted
+
+@dataclass
+class AuditTrail:
+    """Collection of all decision traces in an execution."""
+    traces: List[DecisionTrace] = field(default_factory=list)
+    
+    def add_trace(self, trace: DecisionTrace):
+        self.traces.append(trace)
+
+# Global context variable for audit trail
+_audit_context: ContextVar[Optional[AuditTrail]] = ContextVar('audit_context', default=None)
+
+def start_audit() -> AuditTrail:
+    """
+    Start a new audit session.
+    Returns the AuditTrail object that will collect traces.
+    """
+    trail = AuditTrail()
+    _audit_context.set(trail)
+    return trail
+
+def stop_audit() -> Optional[AuditTrail]:
+    """
+    Stop the current audit session and return the collected trail.
+    """
+    trail = _audit_context.get()
+    _audit_context.set(None)
+    return trail
+
+def is_auditing() -> bool:
+    """Check if auditing is currently active."""
+    return _audit_context.get() is not None
+
+def log_decision(
+    table_title: str,
+    facts: Dict[str, Any],
+    rule_results: List[bool],
+    outputs: List[Any],
+    final_result: List[Dict[str, Any]],
+    input_expressions: List[List[str]] = None,
+    output_expressions: List[List[str]] = None,
+    input_col_ids: List[str] = None,
+    output_col_ids: List[str] = None
+):
+    """
+    Log a decision table execution to the current audit trail.
+    Only logs if auditing is active.
+    """
+    trail = _audit_context.get()
+    if trail is None:
+        return
+    
+    # Find which rules matched
+    matched_rules = [i for i, matched in enumerate(rule_results) if matched]
+    
+    # Helper to evaluate expression with actual values
+    def evaluate_expression(expr: str, facts_dict: Dict[str, Any]) -> str:
+        """Replace variable names in expression with their actual values."""
+        evaluated = expr
+        # Sort by length (longest first) to avoid partial replacements
+        for var_name in sorted(facts_dict.keys(), key=len, reverse=True):
+            value = facts_dict[var_name]
+            # Format the value appropriately
+            if isinstance(value, bool):
+                value_str = str(value).lower()
+            elif isinstance(value, str):
+                value_str = f'"{value}"'
+            else:
+                value_str = str(value)
+            # Replace variable name with value (word boundaries to avoid partial matches)
+            import re
+            evaluated = re.sub(r'\b' + re.escape(var_name) + r'\b', value_str, evaluated)
+        return evaluated
+    
+    trace = DecisionTrace(
+        table_title=table_title,
+        facts=facts.copy(),
+        matched_rules=matched_rules,
+        rule_results=rule_results.copy(),
+        outputs=outputs.copy() if isinstance(outputs, list) else outputs,
+        final_result=final_result.copy() if isinstance(final_result, list) else final_result,
+        input_expressions=input_expressions or [],
+        output_expressions=output_expressions or [],
+        input_col_ids=input_col_ids or [],
+        output_col_ids=output_col_ids or [],
+        evaluated_outputs=[
+            [evaluate_expression(expr, facts) for expr in (row if isinstance(row, list) else [row])]
+            for row in (output_expressions or [])
+        ] if output_expressions else []
+    )
+    
+    trail.add_trace(trace)

--- a/bkflow_dmn/data_model.py
+++ b/bkflow_dmn/data_model.py
@@ -3,7 +3,7 @@ import re
 from enum import Enum
 from typing import List, Union
 
-from pydantic import BaseModel, root_validator
+from pydantic import BaseModel, model_validator
 
 from bkflow_feel.api import parse_expression
 
@@ -35,12 +35,12 @@ class DataTable(BaseModel):
     cols: List[DataTableField]
     rows: List[Union[List[str], str]]
 
-    @root_validator(skip_on_failure=True)
-    def validate_length(cls, values: dict):
-        for row in values["rows"]:
-            if isinstance(row, list) and len(row) != len(values["cols"]):
+    @model_validator(mode="after")
+    def validate_length(self):
+        for row in self.rows:
+            if isinstance(row, list) and len(row) != len(self.cols):
                 raise ValueError("the length of row should be the same as the length of cols")
-        return values
+        return self
 
     @property
     def col_ids(self):
@@ -98,11 +98,11 @@ class SingleDecisionTable(BaseModel):
         
         return final_result
 
-    @root_validator(skip_on_failure=True)
-    def validate_length(cls, values: dict):
-        if len(values["inputs"].rows) != len(values["outputs"].rows):
+    @model_validator(mode="after")
+    def validate_length(self):
+        if len(self.inputs.rows) != len(self.outputs.rows):
             raise ValueError("the length of inputs should be the same as the length of outputs")
-        return values
+        return self
 
     @property
     def hit_policy_value(self):


### PR DESCRIPTION
Hi, I didn't know if is interesting for this project, but I did an small improvement on this library to include the full trace of an decision!

I'm using this project as part of https://github.com/techmaxsolucoes/motor_tributario_py

And I'm able to extract this kind of audit from each execution

```json
{
  "method_name": "calcula_icms",
  "inputs": {
    "tributavel": {
      "valor_produto": 100.0,
      "frete": 0.0,
      "seguro": 0.0,
      "outras_despesas": 0.0,
      "desconto": 0.0,
      "valor_ipi": 0.0,
      "quantidade_produto": 1.0,
      "is_servico": false,
      "is_ativo_imobilizado_ou_uso_consumo": false,
      "tipo_desconto": "Incondicional",
      "cst": "",
      "tipo_calculo_icms_desonerado": "",
      "crt": "",
      "tipo_operacao": "",
      "tipo_pessoa": "",
      "percentual_icms": 18.0,
      "percentual_reducao": 0.0,
      "percentual_ipi": 0.0,
      "percentual_pis": 1.65,
      "percentual_reducao_pis": 0.0,
      "percentual_cofins": 7.6,
      "percentual_reducao_cofins": 0.0,
      "percentual_icms_st": 0.0,
      "percentual_mva": 0.0,
      "percentual_reducao_st": 0.0,
      "percentual_fcp": 0.0,
      "percentual_fcp_st": 0.0,
      "percentual_credito": 0.0,
      "csosn": 0,
      "percentual_fcp_st_retido": 0.0,
      "valor_ultima_base_calculo_icms_st_retido": 0.0,
      "percentual_difal_interna": 0.0,
      "percentual_difal_interestadual": 0.0,
      "percentual_issqn": 0.0,
      "percentual_ret_pis": 0.0,
      "percentual_ret_cofins": 0.0,
      "percentual_ret_csll": 0.0,
      "percentual_ret_irrf": 0.0,
      "percentual_ret_inss": 0.0,
      "percentual_federal": 0.0,
      "percentual_estadual": 0.0,
      "percentual_municipal": 0.0,
      "percentual_federal_importados": 0.0,
      "percentual_ibs_uf": 0.0,
      "percentual_ibs_municipal": 0.0,
      "percentual_cbs": 0.0,
      "percentual_reducao_ibs_uf": 0.0,
      "percentual_reducao_ibs_municipal": 0.0,
      "percentual_reducao_cbs": 0.0,
      "documento": "",
      "percentual_icms_efetivo": 0.0,
      "percentual_reducao_icms_efetivo": 0.0,
      "quantidade_base_calculo_icms_monofasico": 0.0,
      "aliquota_ad_rem_icms": 0.0,
      "percentual_reducao_aliquota_ad_rem_icms": 0.0,
      "percentual_biodiesel": 0.0,
      "percentual_originario_uf": 0.0,
      "quantidade_base_calculo_icms_monofasico_retido_anteriormente": 0.0,
      "aliquota_ad_rem_icms_retido_anteriormente": 0.0,
      "somar_pis_na_base_ibs_cbs": false,
      "somar_cofins_na_base_ibs_cbs": false,
      "somar_icms_na_base_ibs_cbs": false,
      "somar_issqn_na_base_ibs_cbs": false,
      "percentual_diferimento": 0.0,
      "deduz_icms_da_base_de_pis_cofins": false
    },
    "args": [],
    "kwargs": {}
  },
  "result": {
    "base_calculo": 100.0,
    "valor": 18.0,
    "percentual_icms": 18.0,
    "percentual_reducao": 0.0,
    "percentual_icms_st": 0.0,
    "percentual_mva": 0.0,
    "base_calculo_st": null,
    "valor_icms_st": null,
    "percentual_reducao_st": 0.0,
    "percentual_diferimento": 0.0,
    "valor_icms_diferido": null,
    "valor_icms_operacao": null,
    "valor_bc_st_retido": 100.0,
    "base_calculo_icms_efetivo": null,
    "valor_icms_efetivo": null,
    "modalidade_determinacao_bc_icms": "ValorOperacao",
    "modalidade_determinacao_bc_icms_st": null
  },
  "audit_trail": {
    "traces": [
      {
        "table_title": "Full ICMS Calculation Rules",
        "facts": {
          "valor_produto": 100.0,
          "quantidade_produto": 1.0,
          "frete": 0.0,
          "seguro": 0.0,
          "outras_despesas": 0.0,
          "valor_ipi": 0.0,
          "is_ativo": false,
          "tipo_desconto": "Incondicional",
          "desconto": 0.0,
          "percentual_reducao": 0.0,
          "percentual_icms": 18.0
        },
        "matched_rules": [
          3
        ],
        "rule_count": 4,
        "final_result": [
          {
            "base_calculo": 100.0,
            "valor_final": 18.0
          }
        ],
        "matched_rule_details": [
          {
            "rule_number": 4,
            "input_conditions": {
              "is_ativo": "false",
              "tipo_desconto": "\"Incondicional\""
            },
            "output_calculations": {
              "base_calculo": {
                "expression": "( ( ( ( (valor_produto * quantidade_produto) + frete) + seguro) + outras_despesas) - desconto ) * (decimal(1) - (percentual_reducao / decimal(100)))",
                "evaluated": "( ( ( ( (100.00 * 1) + 0) + 0) + 0) - 0 ) * (decimal(1) - (0 / decimal(100)))",
                "result": 100.0
              },
              "valor_final": {
                "expression": "( ( ( ( ( ( (valor_produto * quantidade_produto) + frete) + seguro) + outras_despesas) - desconto ) * (decimal(1) - (percentual_reducao / decimal(100))) ) * percentual_icms) / decimal(100)",
                "evaluated": "( ( ( ( ( ( (100.00 * 1) + 0) + 0) + 0) - 0 ) * (decimal(1) - (0 / decimal(100))) ) * 18.0) / decimal(100)",
                "result": 18.0
              }
            }
          }
        ]
      }
    ]
  }
}
```